### PR TITLE
Replaced travis by GitHub action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "6.10.3"
-cache:
-  yarn: true
-  directories:
-    - "node_modules"


### PR DESCRIPTION
Closes #5
Removed travis ci with GitHub action script. 

To make this work repository secret `NPM_TOKEN` should be created [here](https://github.com/nessgor/telegraf-session-dynamodb/settings/secrets/actions) and a new release in GH should be created.

Thanks!